### PR TITLE
add simple route mechanism

### DIFF
--- a/source/serverino/config.d
+++ b/source/serverino/config.d
@@ -39,13 +39,10 @@ public enum onServerInit;     /// UDA. SeeAlso:ServerinoConfig
 
 import serverino.interfaces : Request;
 
-public struct allowIf(alias T)
+public struct route(alias T)
 {
     static bool apply(Request r) { return T(r); }
 }
-
-import std.string : stripRight;
-
 
 private template compareUri(string _uri)
 {
@@ -55,7 +52,7 @@ private template compareUri(string _uri)
     };
 }
 
-public alias allowIf(string uri) = allowIf!(r => compareUri!uri(r));
+public alias route(string uri) = route!(r => compareUri!uri(r));
 
 /++
    Struct used to setup serverino.

--- a/source/serverino/config.d
+++ b/source/serverino/config.d
@@ -37,7 +37,26 @@ public enum onWorkerStart;    /// UDA. Functions with @onWorkerStart attached ar
 public enum onWorkerStop;     /// UDA. Functions with @onWorkerStop attached are called when worker is stopped
 public enum onServerInit;     /// UDA. SeeAlso:ServerinoConfig
 
-public struct route{ immutable(string) _route; }
+import serverino.interfaces : Request;
+
+public struct allowIf(alias T)
+{
+    static bool apply(Request r) { return T(r); }
+}
+
+import std.string : stripRight;
+
+
+private template compareUri(string _uri)
+{
+    enum compareUri = (Request r){
+        static assert(_uri[0] == '/', "Every route must begin with a '/'");
+        enum udaURI = _uri.stripRight(['/']);
+        return r.uri.stripRight(['/']) == udaURI;
+    };
+}
+
+public alias allowIf(string uri) = allowIf!(r => compareUri!uri(r));
 
 /++
    Struct used to setup serverino.

--- a/source/serverino/config.d
+++ b/source/serverino/config.d
@@ -51,8 +51,7 @@ private template compareUri(string _uri)
 {
     enum compareUri = (Request r){
         static assert(_uri[0] == '/', "Every route must begin with a '/'");
-        enum udaURI = _uri.stripRight(['/']);
-        return r.uri.stripRight(['/']) == udaURI;
+        return r.uri == _uri;
     };
 }
 

--- a/source/serverino/config.d
+++ b/source/serverino/config.d
@@ -37,6 +37,8 @@ public enum onWorkerStart;    /// UDA. Functions with @onWorkerStart attached ar
 public enum onWorkerStop;     /// UDA. Functions with @onWorkerStop attached are called when worker is stopped
 public enum onServerInit;     /// UDA. SeeAlso:ServerinoConfig
 
+public struct route{ immutable(string) _route; }
+
 /++
    Struct used to setup serverino.
    You must return this struct from a function with @onServerInit UDA attached.

--- a/source/serverino/worker.d
+++ b/source/serverino/worker.d
@@ -687,13 +687,13 @@ struct Worker
 
                   static if (__traits(compiles, f(request, output)))
                   {
-                    static if (hasUDA!(f, allowIf))
+                    static if (hasUDA!(f, route))
                     {
                       bool willLaunch = false;
                       static foreach(attr;  __traits(getAttributes, f))
                       {
                         {
-                          static if(__traits(isSame, TemplateOf!(attr), allowIf)){
+                          static if(__traits(isSame, TemplateOf!(attr), route)){
                             if(attr.apply(request)) willLaunch = true;
                           }
                         }
@@ -706,13 +706,13 @@ struct Worker
                   }
                   else static if (__traits(compiles, f(request))) // ditto
                   { 
-                    static if (hasUDA!(f, allowIf))
+                    static if (hasUDA!(f, route))
                     {
                       bool willLaunch = false;
                       static foreach(attr;  __traits(getAttributes, f))
                       {
                         {
-                          static if(__traits(isSame, TemplateOf!(attr), allowIf)){
+                          static if(__traits(isSame, TemplateOf!(attr), route)){
                             if(attr.apply(request)) willLaunch = true;
                           }
                         }

--- a/source/serverino/worker.d
+++ b/source/serverino/worker.d
@@ -684,7 +684,6 @@ struct Worker
                   alias f = __traits(getMember,currentMod, ff.name);
                   
                   import std.traits : hasUDA, TemplateOf;
-                  import std.string : stripRight;
 
                   static if (__traits(compiles, f(request, output)))
                   {

--- a/source/serverino/worker.d
+++ b/source/serverino/worker.d
@@ -690,6 +690,7 @@ struct Worker
                     static if (hasUDA!(f, route)){
                         static assert(getUDAs!(f, route).length == 1, "Only one route must be assigned to a function!");
                         enum udaRoute = getUDAs!(f, route)[0]._route.stripRight(['/']);
+                        static assert(udaRoute[0] == '/', "Every route must begin with a '/'");
                         // serverino yields 404 if there is @route definition and this doesn't match
                         if(udaRoute == request.uri.stripRight(['/'])) 
                             f(request, output);
@@ -701,6 +702,7 @@ struct Worker
                     static if (hasUDA!(f, route)){
                         static assert(getUDAs!(f, route).length == 1, "Only one route must be assigned to a function!");
                         enum udaRoute = getUDAs!(f, route)[0]._route.stripRight(['/']);
+                        static assert(udaRoute[0] == '/', "Every route must begin with a '/'");
                         // serverino yields 404 if there is @route definition and this doesn't match
                         if(udaRoute == request.uri.stripRight(['/']))
                             f(request);


### PR DESCRIPTION
Hi @trikko,

This PR allows users to assign routes to functions like:

@route("/foo/bar")
@endpoint void hello(Request req, Output output)
{
   output ~= "Hello world!";
}

if a request is miswritten like "/foo/ba" by the user, serverino will yield 404. If there is no route defined, everything will work as usual. Another possible implementation would be making the enum endPoint a struct and route as a member. I don't know maybe?

Please review my PR and tell me if I need to cover more use cases.

Best regards.